### PR TITLE
py3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ nodb.save(user) # True
 
 # Load our object!
 user = nodb.load("Jeff")
-print user.age # 19
+print(user.age) # 19
 
 # Delete our object
 nodb.delete("Jeff") # True
@@ -75,7 +75,7 @@ class User(object):
     age = None
 
     def print_name(self):
-        print "Hi, I'm " + self.name + "!"
+        print("Hi, I'm " + self.name + "!")
 
 new_user = User()
 new_user.name = "Jeff"


### PR DESCRIPTION
got rid of base64 stuff
using six to get correct bytes type
serializing the whole object by desired type and not doing the json wrap if pickle. Keeps it simpler.

Double check my encoding stuff. Works for me but I hate it, so have little confidence in encoding/decoding crap