### PR TITLE
Light touch python 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ nodb.save(user) # True
 
 # Load our object!
 user = nodb.load("Jeff")
-print user['age'] # 19
+print(user['age']) # 19
 
 # Delete our object
 nodb.delete("Jeff") # True
@@ -80,7 +80,7 @@ class User(object):
     age = None
 
     def print_name(self):
-        print "Hi, I'm " + self.name + "!"
+        print("Hi, I'm " + self.name + "!")
 
 new_user = User()
 new_user.name = "Jeff"

--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -33,6 +33,7 @@ class NoDB(object):
     prefix = ".nodb/"
     signature_version = "s3v4"
     cache = False
+    encoding = 'utf8'
 
     s3 = boto3.resource('s3', config=botocore.client.Config(signature_version=signature_version))
 
@@ -66,7 +67,7 @@ class NoDB(object):
 
         # Then, store.
         bytesIO = BytesIO()
-        bytesIO.write(serialized)
+        bytesIO.write(serialized.encode(self.encoding))
         bytesIO.seek(0)
 
         s3_object = self.s3.Object(self.bucket, self.prefix + real_index)
@@ -86,7 +87,7 @@ class NoDB(object):
             if not os.path.exists(cache_path):
                 open(cache_path, 'w+').close()
             with open(cache_path, "wb") as in_file:
-                in_file.write(serialized)
+                in_file.write(serialized.encode(self.encoding))
             logging.debug("Wrote to cache file: " + cache_path)
 
         return resp
@@ -132,7 +133,7 @@ class NoDB(object):
                     open(cache_path, 'w+').close()
 
                 with open(cache_path, "wb") as in_file:
-                    in_file.write(serialized)
+                    in_file.write(serialized.encode(self.encoding))
 
                 logging.debug("Wrote to cache file: " + cache_path)
 
@@ -190,8 +191,7 @@ class NoDB(object):
         packed['uuid'] = str(uuid.uuid4())
 
         if self.serializer == 'pickle':
-            # TODO: Python3
-            packed['obj'] = str(base64.b64encode(pickle.dumps(obj)))
+            packed['obj'] = base64.b64encode(pickle.dumps(obj)).decode(self.encoding)
         elif self.serializer == 'json':
             packed['obj'] = obj
         else:
@@ -213,8 +213,7 @@ class NoDB(object):
             if self.serializer != 'pickle':
                 raise Exception("Security exception: Won't unpickle if not set to pickle.")
 
-            # TODO: Python3
-            return_me['obj'] = pickle.loads(base64.b64decode(deserialized['obj']))
+            return_me['obj'] = pickle.loads(base64.b64decode(deserialized['obj'].encode(self.encoding)))
 
         elif deserialized['serializer'] == 'json':
             return_me['obj'] = deserialized['obj']
@@ -238,7 +237,7 @@ class NoDB(object):
 
         index_value = None
         if type(obj) is dict:
-            if obj.has_key(index):
+            if index in obj:
                 index_value = obj[index]
             else:
                 raise Exception("Dict object has no key: " + str(index))
@@ -261,7 +260,7 @@ class NoDB(object):
             # You are on your own here! This may not work!
             return index_value
         else:
-            return self.hash_function(bytes(index_value)).hexdigest()
+            return self.hash_function(index_value.encode(self.encoding)).hexdigest()
 
     def _get_base_cache_path(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ jmespath>=0.9.2
 packaging>=16.8
 pbr>=2.0.0
 pyparsing>=2.2.0
-python-dateutil>=2.6.0
+python-dateutil==2.6.0
 s3transfer>=0.1.10
 six>=1.10.0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -80,7 +80,7 @@ class TestNoDB(unittest.TestCase):
             f.close()
 
         with open(cache_path, "wb") as in_file:
-            in_file.write(serialized)
+            in_file.write(serialized.encode(NoDB.encoding))
 
         nodb.load("Jeff")
         loaded = nodb.load("Jeff", default={})


### PR DESCRIPTION
It looks like mcrowson's pull request for python compatibility has stalled.  If not, feel free to reject this.  

This is a super simple compatibility patch that does little more than use encode/decode and a configurable encoding to ensure data is either in byte or unicode representation when it needs to be.

Since it uses encode/decode methods of string I believe it will require something newer than python 2.2, which seems reasonable at this point.  

There are no new dependencies and all the unit tests passed for me.  I ran some live tests and got up to 83% coverage.   I created a record with the master branch and was able to read it properly using this branch running under python 2 and python 3.  

Anyway this is my attempt to jump start getting the project up to python 3, which I need for purely selfish reasons.  :)

If there are any anything I missed, let me know and I'll try and get it fixed. 