### PR TITLE
Allow using custom AWS S3 host for docker development

### DIFF
--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -33,8 +33,7 @@ class NoDB(object):
     prefix = ".nodb/"
     signature_version = "s3v4"
     cache = False
-
-    s3 = boto3.resource('s3', config=botocore.client.Config(signature_version=signature_version))
+    aws_s3_host = None
 
     ##
     # Advanced config
@@ -47,6 +46,14 @@ class NoDB(object):
     ##
     # Public Interfaces
     ##
+    @property
+    def s3(self):
+        s3 = boto3.resource(
+            's3',
+            config=botocore.client.Config(signature_version=self.signature_version),
+            endpoint_url=self.aws_s3_host
+        )
+        return s3
 
     def save(self, obj, index=None):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -90,5 +90,12 @@ class TestNoDB(unittest.TestCase):
 
         bcp = nodb._get_base_cache_path()
 
+    def test_s3_resource(self):
+        self.assertTrue(True)
+        nodb = NoDB()
+        nodb.aws_s3_host = 'http://fakes3'
+        self.assertTrue('s3.ServiceResource' in str(type(nodb.s3)))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

Need to be able to run NoDB in local environments, where AWS S3 can be some random container and not actually AWS S3 (for example using minio)

## Solution

- Added `aws_s3_host` attribute
- Converted `self.s3` to be a `@property`

## Manual testing

1. Create a local environment of s3 with docker (I tested with [minio](https://github.com/minio/minio) and listening on port 9000). After that create a NoDB instance, change the host to be the local one:
```
(.venv) britecorio@Ivans-MacBook-Pro:~/git/NoDB(master⚡) » docker run -p 9000:9000  minio/minio server /data
Created minio configuration file successfully at /root/.minio

Drive Capacity: 31 GiB Free, 60 GiB Total

Endpoint:  http://172.17.0.2:9000  http://127.0.0.1:9000
AccessKey: XCLV2JO1CXZV1U02DN55
SecretKey: cC6z0P3WhoPIZCSG7eK48/S12o93B2MTsc97Cse2
```

2. Log in to minio locally with the generated keys (http://localhost:9000/) and create a new bucket named `people`:
![image](https://user-images.githubusercontent.com/815440/40320482-7e21558c-5cf1-11e8-9ae1-0c95efe3830c.png)

3. Run this script (as .py, ipython, etc) 
```python
import os

from nodb import NoDB

# CHANGE THESE TO BE THE ONES YOUR DOCKER MINIO GENERATED
os.environ['AWS_ACCESS_KEY_ID'] = 'XCLV2JO1CXZV1U02DN55'
os.environ['AWS_SECRET_ACCESS_KEY'] = 'cC6z0P3WhoPIZCSG7eK48/S12o93B2MTsc97Cse2'

nodb = NoDB()
nodb.aws_s3_host = 'http://localhost:9000'
nodb.bucket = 'people'
nodb.index = 'name'
nodb.human_readable_indexes = True

user = {'name': 'Rony', 'age': 4}
nodb.save(user)
```

4. Refresh local browser and check that the file got stored to local s3:
![image](https://user-images.githubusercontent.com/815440/40320585-d06fafaa-5cf1-11e8-9818-a2a8527b6183.png)
