### PR TITLE
aws session and profile_name values passable on NoDB.__init__

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ You can enable local file caching, which will store previously retrieved values 
 nodb.cache = True
 ```
 
+### AWS settings override
+
+You can override your AWS Profile information or boto3 session by passing either as a initial keyword argument.
+
+```python
+nodb = NoDB(profile_name='my_aws_development_profile')
+# or supply the session
+session = boto3.Session(
+    aws_access_key_id=ACCESS_KEY,
+    aws_secret_access_key=SECRET_KEY,
+    aws_session_token=SESSION_TOKEN,
+)
+nodb = NoDB(session=session)
+```
+
+
+
 ## TODO (Maybe?)
 
 * **Tests** with Placebo

--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -34,8 +34,17 @@ class NoDB(object):
     signature_version = "s3v4"
     cache = False
     encoding = 'utf8'
+    profile_name = None
 
     s3 = boto3.resource('s3', config=botocore.client.Config(signature_version=signature_version))
+
+    def __init__(self, profile_name=None, session=None):
+        if profile_name:
+            self.profile_name = profile_name
+        if self.profile_name:
+            session = boto3.session.Session(profile_name=self.profile_name)
+        if session:
+            self.s3 = session.resource('s3', config=botocore.client.Config(signature_version=self.signature_version))
 
     ##
     # Advanced config


### PR DESCRIPTION
My AWS_DEFAULT .env value wasn't working, so for development I needed to pass my profile directly, expanded this to take session as a kwarg to make it more flexible, I'm sure there might be a number of people who could use this override.'

also included @nephlm 's py3 compatibility changes, as this is the branch I'm using.