### PR TITLE
Remove unnecessary .encode when writing to cache

### DIFF
--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -142,7 +142,7 @@ class NoDB(object):
                     open(cache_path, 'w+').close()
 
                 with open(cache_path, "wb") as in_file:
-                    in_file.write(serialized.encode(self.encoding))
+                    in_file.write(serialized)
 
                 logging.debug("Wrote to cache file: " + cache_path)
 


### PR DESCRIPTION
## Issue

The body of an object is read in as bytes in python 3 (at least sometimes?). When the cache option is on, NoDB will then attempt to call `.encode()` on these bytes and then write that to the cache file. However this method was removed in python 3, so error something like:
```
  File "/opt/conda/lib/python3.6/site-packages/nodb/__init__.py", line 145, in load
    in_file.write(serialized.encode(self.encoding))
AttributeError: 'bytes' object has no attribute 'encode'
```
is raised.

## Solution

I think simply removing the `.encode()` should be fine, as python 2/3 can write bytes or str to a file just fine. Let me know if I have misunderstood what that line is supposed to be doing.