### PR TITLE
escape human readable paths, allow prefixed queries, integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - "pip install setuptools --upgrade; pip install -r test_requirements.txt; python setup.py install"
 # command to run tests
 env:
-  - AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar TESTCASE=tests/tests.py
+  - AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar TESTCASE=tests/unit_tests.py
 script: 
   - nosetests $TESTCASE --with-coverage --cover-package=nodb --with-timer
     #  - coverage combine --append

--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -101,7 +101,8 @@ class NoDB(object):
             if not os.path.exists(os.path.dirname(os.path.abspath(cache_path))):
                 os.makedirs(os.path.dirname(os.path.abspath(cache_path)))
             with open(cache_path, "wb") as in_file:
-                in_file.write(serialized.encode(self.encoding))
+                serialized = pickle.dump(serialized, in_file)
+                # in_file.write(serialized.encode(self.encoding))
             logging.debug("Wrote to cache file: " + cache_path)
 
         return resp
@@ -124,7 +125,8 @@ class NoDB(object):
             # Cache hit!
             if os.path.isfile(cache_path):
                 with open(cache_path, "rb") as in_file:
-                    serialized = in_file.read()
+                    serialized = pickle.load(in_file)
+                    # serialized = in_file.read()
                 cache_hit = True
                 logging.debug("Loaded bytes from cache file: " + cache_path)
             else:
@@ -147,7 +149,8 @@ class NoDB(object):
                     os.makedirs(os.path.dirname(os.path.abspath(cache_path)))
 
                 with open(cache_path, "wb") as in_file:
-                    in_file.write(serialized.encode(self.encoding))
+                    pickle.dump(serialized, in_file)
+                    # in_file.write(serialized.encode(self.encoding))
                 logging.debug("Wrote to cache file: " + cache_path)
 
         # Then read the data format

--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -36,6 +36,7 @@ class NoDB(object):
     profile_name = None
     bucket = None
     invalid_s3_path_pattern = re.compile("[^0-9a-zA-Z!\-_.*'()/]")
+    custom_index_func = None
 
     s3 = boto3.resource('s3', config=botocore.client.Config(signature_version=signature_version))
 
@@ -279,7 +280,9 @@ class NoDB(object):
         """
 
         index_value = None
-        if type(obj) is dict:
+        if self.custom_index_func:
+           index_value = self.custom_index_func(obj, index)
+        elif type(obj) is dict:
             if index in obj:
                 index_value = obj[index]
             else:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(os.path.dirname(__file__), 'test_requirements.txt')) as f
 
 setup(
     name='nodb',
-    version='0.4.0',
+    version='0.4.1',
     packages=['nodb'],
     install_requires=required,
     tests_require=test_required,

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,0 +1,30 @@
+# -*- coding: utf8 -*-
+import random
+import string
+import unittest
+from nodb import NoDB
+
+
+class TestNoDBIntegration(unittest.TestCase):
+
+    def test_nodb_save_load_all_subpath(self):
+        bucket_name = 'noahonnumbers-blog'
+
+        nodb = NoDB(bucket_name)
+        nodb.human_readable_indexes = True
+        nodb.index = "path"
+
+        jeff = {"Name": "Jeff", "age": 19, "path": "persons/jeff", "type": "person"}
+        michael = {"Name": "Michael", "age": 19, "path": "persons/michael", "type": "person"}
+        car = {"Name": "Acura TSX", "path": "vehicles/car", "type": "vehicle"}
+
+        nodb.save(jeff)
+        nodb.save(michael)
+        nodb.save(car)
+
+        persons = nodb.all(subpath="persons/")
+        self.assertListEqual([jeff, michael], persons)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -146,6 +146,28 @@ class TestNoDB(unittest.TestCase):
         all_objects = nodb.all()
         self.assertListEqual([{"Name": "John", "age": 19}, {"Name": "Jane", "age": 20}], all_objects)
 
+    @moto.mock_s3
+    def test_nodb_all_subpath(self):
+        # create dummy bucket and store some objects
+        bucket_name = 'dummy_bucket_12345_qwerty'
+        self._create_mock_bucket(bucket_name)
+
+        nodb = NoDB(bucket_name)
+        nodb.human_readable_indexes = True
+        nodb.index = "path"
+
+        jeff = {"Name": "Jeff", "age": 19, "path": "persons/jeff", "type": "person"}
+        michael = {"Name": "Michael", "age": 19, "path": "persons/michael", "type": "person"}
+        car = {"Name": "Acura TSX", "path": "vehicles/car", "type": "vehicle"}
+
+        nodb.save(jeff)
+        nodb.save(michael)
+        nodb.save(car)
+
+        persons = nodb.all(subpath="persons/")
+        self.assertListEqual([jeff, michael], persons)
+
+
     def _create_mock_bucket(self, bucket_name):
         boto3.resource('s3').Bucket(bucket_name).create()
 


### PR DESCRIPTION
Wanted the ability to save different object types and load them all based on type, so using the s3 path as the index with human_readable_index=True.