### PR TITLE
Added support for custom prefix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ pip install nodb
 
 **NoDB** is super easy to use!
 
-You simply make a NoDB object, point it to your bucket, and tell it what field you want to index on.
+You simply make a NoDB object, point it to your bucket and tell it what field you want to index on.
 
 ```python
 from nodb import NoDB

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ pip install nodb
 
 **NoDB** is super easy to use!
 
-You simply make a NoDB object, point it to your bucket and tell it what field you want to index on.
+You simply make a NoDB object, point it to your bucket, and tell it what field you want to index on.
 
 ```python
 from nodb import NoDB
@@ -67,6 +67,13 @@ print(user['age']) # 19
 
 # Delete our object
 nodb.delete("Jeff") # True
+```
+The data files are stored in your bucket under a folder named `.nodb` however, you can customize it  passing in the parameter `prefix` when initializing the `NoDb` class.
+```python
+from nodb import NoDB
+
+nodb = NoDB("my-s3-bucket", prefix='clients') 
+# This will create a folder called .clients under my-s3-bucket 
 ```
 
 By default, you can save and load any Python object.

--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -28,12 +28,9 @@ class NoDB(object):
     backend = "s3"
     serializer = "pickle"
     index = "id"
-    prefix = None
     signature_version = "s3v4"
     cache = False
     encoding = 'utf8'
-    profile_name = None
-    bucket = None
 
     s3 = boto3.resource('s3', config=botocore.client.Config(signature_version=signature_version))
 
@@ -49,19 +46,16 @@ class NoDB(object):
     # Public Interfaces
     ##
 
-    def __init__(self, bucket=None, prefix=".nodb/", profile_name=None, session=None):
+    def __init__(self, bucket, prefix=".nodb/", profile_name=None, session=None):
 
         if not prefix == ".nodb/":
             prefix = os.path.join(prefix, '')  # make sure ends with '/'
             prefix = prefix if prefix.startswith('.') else '.'.join(['', prefix])  # make sure begins with '.'
 
         self.prefix = prefix
-
-        if bucket:
-            self.bucket = bucket
+        self.bucket = bucket
         if profile_name:
             self.profile_name = profile_name
-        if self.profile_name:
             session = boto3.session.Session(profile_name=self.profile_name)
         if session:
             self.s3 = session.resource('s3', config=botocore.client.Config(signature_version=self.signature_version))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,7 @@ import unittest
 
 import boto3
 import moto
-from botocore.exceptions import NoCredentialsError, ProfileNotFound
+from botocore.exceptions import ProfileNotFound
 
 from nodb import NoDB
 
@@ -145,6 +145,23 @@ class TestNoDB(unittest.TestCase):
 
         all_objects = nodb.all()
         self.assertListEqual([{"Name": "John", "age": 19}, {"Name": "Jane", "age": 20}], all_objects)
+
+    @moto.mock_s3
+    def test_nodb_custom_prefix_save_load(self):
+        # create dummy bucket and store some objects
+        bucket_name = 'dummy_bucket'
+
+        self._create_mock_bucket(bucket_name)
+
+        nodb = NoDB(bucket_name, prefix='JeffPrefix')
+        nodb.index = "Name"
+
+        jeff = {"Name": "Jeff", "age": 19}
+
+        nodb.save(jeff)
+        possible_jeff = nodb.load('Jeff')
+        self.assertEqual(nodb.prefix, '.JeffPrefix/')
+        self.assertEqual(possible_jeff, jeff)
 
     def _create_mock_bucket(self, bucket_name):
         boto3.resource('s3').Bucket(bucket_name).create()


### PR DESCRIPTION
Added support for specifying the custom prefix that ultimately translates as the folder where the files will be stored. The developer can now re-use a single bucket to partion the data in separated folders. i.e., for different projects, purposes, or just a way to  'normalize' the data.