### PR TITLE
Remove deprecated 'rb' mode

### DIFF
--- a/nodb/__init__.py
+++ b/nodb/__init__.py
@@ -81,7 +81,7 @@ class NoDB(object):
         bytesIO.seek(0)
 
         s3_object = self.s3.Object(self.bucket, self.prefix + real_index)
-        result = s3_object.put('rb', Body=bytesIO)
+        result = s3_object.put(Body=bytesIO)
         logging.debug("Put remote bytes: " + self.prefix + real_index)
 
         if result['ResponseMetadata']['HTTPStatusCode'] == 200:


### PR DESCRIPTION
I started getting the error `[ERROR] TypeError: put_object() only accepts keyword arguments.` at 

```
  File "/var/task/nodb/__init__.py", line 83, in save
    result = s3_object.put('rb', Body=bytesIO)
```

in Python 3.8. This is on Lambda, I believe it has boto3-1.12.22 and botocore-1.15.22.

The write mode appears to be deprecated and this fixes it.